### PR TITLE
Fix misspelling in ClipboardItems.swift

### DIFF
--- a/Macboard/Views/ClipboardItems.swift
+++ b/Macboard/Views/ClipboardItems.swift
@@ -224,7 +224,7 @@ struct ClipboardItemListView: View {
                         withAnimation {
                             dataManager.clearClipboard(clearPins: clearPins)
                             selectedItem = nil
-                            showToast("Cleard the clipboard history")
+                            showToast("Cleared the clipboard history")
                         }
                     }
                     Button("No", role: .destructive) { }


### PR DESCRIPTION
`cleard` --> `cleared` 